### PR TITLE
hotfix: solicitações do mesmo dia e do mesmo tipo agora são bloqueadas

### DIFF
--- a/src/services/solicitacaoServices.ts
+++ b/src/services/solicitacaoServices.ts
@@ -62,6 +62,40 @@ const getSolicitacaoById = async (id: number): Promise<SolicitacaoInterface | Ap
 
 const createSolicitacao = async (formData: FormData): Promise<SolicitacaoInterface | ApiException> => {
   try {
+    let objectFormData:Record<string, any> = {}
+
+    for (let i of formData.entries()) {
+      objectFormData[i[0]] = i[1]; 
+    }
+
+    const jsonString = objectFormData["solicitacaoJson"];
+    const dataSolicitacao = JSON.parse(jsonString);
+
+    const solicitacaoDataPeriodo = dataSolicitacao["solicitacaoDataPeriodo"];
+    const usuarioCod = dataSolicitacao["usuarioCod"];
+    const tipoSolicitacaoCod = dataSolicitacao.tipoSolicitacaoCod.tipoSolicitacaoCod;
+
+    console.log(solicitacaoDataPeriodo, usuarioCod, tipoSolicitacaoCod);
+
+    const solicitacoes = await getAllSolicitacaoByUsuario(usuarioCod);
+
+    if (solicitacoes instanceof ApiException) {
+      throw solicitacoes; // ou trate de outra forma
+    }
+    
+    const solicitacoesExistentes = solicitacoes as any[];
+
+    // 2. Verificar se já existe uma solicitação do mesmo tipo e mesma data
+    const jaExiste = solicitacoesExistentes.some((sol: any) => {
+      const mesmaData = sol.solicitacaoDataPeriodo === solicitacaoDataPeriodo;
+      const mesmoTipo = sol.tipoSolicitacaoCod?.tipoSolicitacaoCod === tipoSolicitacaoCod;
+      return mesmaData && mesmoTipo;
+    });
+        
+    if (jaExiste) {
+      throw new ApiException("Já existe uma solicitação do mesmo tipo neste dia.");
+    }
+
     const { data } = await ApiSolicitacao.post("/solicitacao/cadastrar", formData, {
       headers: { 'Content-Type': 'multipart/form-data' }
     });


### PR DESCRIPTION
# | Bloqueio de solicitações iguais no mesmo dia | #

### O que foi feito: ###
- Alteração da lógica do createSolicitação no solicitaçãoServices, checkando primeiro se a solicitação existe antes de cadastrar e retorna erro caso positivo

### Passos para testar: ###
1. criar uma solicitação
2. criar outra solicitação igual a primeira

### Checklist 
- [x] Atualizado com a develop
- [x] Dentro dos critérios de aceitação
- [x] Adicionado novas dependências
- [x] Código limpo e comentado
- [x] Dentro dos padrões de Projeto